### PR TITLE
allow np.int64 for style_single_glyph()

### DIFF
--- a/logomaker/src/Logo.py
+++ b/logomaker/src/Logo.py
@@ -583,8 +583,8 @@ class Logo:
         """
 
         # validate p is an integer
-        check(isinstance(p, int),
-              'type(p) = %s must be of type int' % type(p))
+        check(isinstance(p, (int, np.int64)),
+              'type(p) = %s must be of type int or numpy.int64' % type(p))
 
         # check p is a valid position
         check(p in self.glyph_df.index,


### PR DESCRIPTION
Dataframes can have numpy.int64 as the index dtype. This change allows Logo.style_single_glyph() and Logo.style_glyphs_in_sequence() to work with such dataframes without throwing an error.