### PR TITLE
Fix: convert LogomakerError to string before feeding it to warnings.warn

### DIFF
--- a/logomaker/src/error_handling.py
+++ b/logomaker/src/error_handling.py
@@ -55,7 +55,7 @@ def check(condition: bool, message: str, warn: bool = None):
     if not condition:
         Error = LogomakerError(message)
         if warn:
-            warnings.warn(Error)
+            warnings.warn(str(Error))
         else:
             raise Error
 


### PR DESCRIPTION
This was causing `TypeError: expected string or bytes-like object, got 'LogomakerError'` (in python 3.11)